### PR TITLE
add sign in redirect

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -5,6 +5,10 @@ class ApplicationController < ActionController::Base
 
   before_action :new_user_params, if: :devise_controller?
 
+  def after_sign_in_path_for(resource)
+    plants_path
+  end
+
   protected
 
     def new_user_params


### PR DESCRIPTION
Used after_sign_in_path_for method in Devise to direct user to search page after signing in